### PR TITLE
Generic error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1.15.0", features = ["sync", "time"] }
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = ["macros", "rt-multi-thread"] }
+thiserror = "1"
 
 [features]
 default = ["queues"]

--- a/src/auxtx.rs
+++ b/src/auxtx.rs
@@ -39,7 +39,7 @@ mod test {
 
     use crate::auxtx::*;
     use crate::{
-        abort, atomically, atomically_aux, atomically_or_err_aux, retry, test::TestError, TVar,
+        abort, atomically, atomically_aux, atomically_or_err_aux, retry, test::TestError1, TVar,
     };
 
     #[derive(Clone)]
@@ -99,11 +99,11 @@ mod test {
     async fn aux_commit_rollback() {
         let db = TestAuxDb::new();
 
-        atomically_or_err_aux(
+        atomically_or_err_aux::<_, TestError1, _, _, _>(
             || db.begin(),
             |atx| {
                 atx.counter = 1;
-                abort(TestError)?;
+                abort(TestError1)?;
                 Ok(())
             },
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 #[cfg(feature = "unstable")]
 extern crate test as etest;
 
-use std::error::Error;
-
 mod ops;
 mod transaction;
 mod vars;
@@ -27,7 +25,8 @@ pub use ops::{
 #[cfg(feature = "queues")]
 pub mod queues;
 
-pub enum StmError {
+/// Transaction shortcutting signals handled by the STM framework.
+pub enum StmControlError {
     /// The transaction failed because a value changed.
     /// It can be retried straight away.
     Failure,
@@ -38,24 +37,32 @@ pub enum StmError {
 }
 
 /// STM error extended with the ability to abort the transaction
-/// with a dynamic error. It is separate so that we rest assured
-/// that `atomically` will not throw an error, that only
-/// `atomically_or_err` allows abortions.
-pub enum StmDynError {
+/// with an error. It is separate so that we rest assured
+/// that [atomically] will not return an error, that only
+/// [atomically_or_err] allows abortions.
+pub enum StmError<T> {
     /// Regular error.
-    Control(StmError),
+    Control(StmControlError),
     /// Abort the transaction and return an error.
-    Abort(Box<dyn Error + Send + Sync>),
+    Abort(T),
 }
 
-impl From<StmError> for StmDynError {
-    fn from(e: StmError) -> Self {
-        StmDynError::Control(e)
+/// Conversion to allow mixing methods returning [StmResult]
+/// with ones returning [StmAbortable] using the `?` operator.
+impl<E> From<StmControlError> for StmError<E> {
+    fn from(e: StmControlError) -> Self {
+        StmError::Control(e)
     }
 }
 
-pub type StmResult<T> = Result<T, StmError>;
-pub type StmDynResult<T> = Result<T, StmDynError>;
+/// Type returned by STM methods that cannot be aborted,
+/// the only reason they can fail is to be retried.
+pub type StmResult<T> = Result<T, StmControlError>;
+
+/// Type returned by STM methods that can be aborted with an error.
+///
+/// Such methods must be executed with [atomically_or_err].
+pub type StmAbortable<T, E> = Result<T, StmError<E>>;
 
 #[cfg(test)]
 mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use ops::{
 pub mod queues;
 
 /// Transaction shortcutting signals handled by the STM framework.
-pub enum StmControlError {
+pub enum StmControl {
     /// The transaction failed because a value changed.
     /// It can be retried straight away.
     Failure,
@@ -40,29 +40,29 @@ pub enum StmControlError {
 /// with an error. It is separate so that we rest assured
 /// that [atomically] will not return an error, that only
 /// [atomically_or_err] allows abortions.
-pub enum StmError<T> {
+pub enum StmError<E> {
     /// Regular error.
-    Control(StmControlError),
+    Control(StmControl),
     /// Abort the transaction and return an error.
-    Abort(T),
+    Abort(E),
 }
 
-/// Conversion to allow mixing methods returning [StmResult]
-/// with ones returning [StmAbortable] using the `?` operator.
-impl<E> From<StmControlError> for StmError<E> {
-    fn from(e: StmControlError) -> Self {
+/// Conversion to allow mixing methods returning [Stm]
+/// with ones returning [StmResult] using the `?` operator.
+impl<E> From<StmControl> for StmError<E> {
+    fn from(e: StmControl) -> Self {
         StmError::Control(e)
     }
 }
 
 /// Type returned by STM methods that cannot be aborted,
 /// the only reason they can fail is to be retried.
-pub type StmResult<T> = Result<T, StmControlError>;
+pub type Stm<T> = Result<T, StmControl>;
 
 /// Type returned by STM methods that can be aborted with an error.
 ///
 /// Such methods must be executed with [atomically_or_err].
-pub type StmAbortable<T, E> = Result<T, StmError<E>>;
+pub type StmResult<T, E> = Result<T, StmError<E>>;
 
 #[cfg(test)]
 mod test;

--- a/src/queues/mod.rs
+++ b/src/queues/mod.rs
@@ -3,18 +3,18 @@ pub mod tchan;
 pub mod tqueue;
 pub mod tvecdequeue;
 
-use crate::StmResult;
+use crate::Stm;
 
 /// Transactional queue-like structure.
 ///
 /// This is a common interface between the various implementations in Simon Marlow's book.
 pub trait TQueueLike<T>: Clone + Send {
     /// Pop the head of the queue, or retry until there is an element if it's empty.
-    fn read(&self) -> StmResult<T>;
+    fn read(&self) -> Stm<T>;
     /// Push to the end of the queue.
-    fn write(&self, value: T) -> StmResult<()>;
+    fn write(&self, value: T) -> Stm<()>;
     /// Check if the queue is empty.
-    fn is_empty(&self) -> StmResult<bool>;
+    fn is_empty(&self) -> Stm<bool>;
 }
 
 #[cfg(test)]

--- a/src/queues/tbqueue.rs
+++ b/src/queues/tbqueue.rs
@@ -1,6 +1,6 @@
 use super::TQueueLike;
 use crate::test_queue_mod;
-use crate::{guard, retry, StmResult, TVar};
+use crate::{guard, retry, Stm, TVar};
 use std::any::Any;
 
 /// Bounded queue using two vectors.
@@ -32,7 +32,7 @@ impl<T> TQueueLike<T> for TBQueue<T>
 where
     T: Any + Sync + Send + Clone,
 {
-    fn write(&self, value: T) -> StmResult<()> {
+    fn write(&self, value: T) -> Stm<()> {
         let capacity = self.capacity.read()?;
         guard(*capacity > 0)?;
         self.capacity.write(*capacity - 1)?;
@@ -43,7 +43,7 @@ where
         self.write.write(v)
     }
 
-    fn read(&self) -> StmResult<T> {
+    fn read(&self) -> Stm<T> {
         let capacity = self.capacity.read()?;
         self.capacity.write(*capacity + 1)?;
 
@@ -70,7 +70,7 @@ where
         }
     }
 
-    fn is_empty(&self) -> StmResult<bool> {
+    fn is_empty(&self) -> Stm<bool> {
         if self.read.read()?.is_empty() {
             Ok(self.write.read()?.is_empty())
         } else {

--- a/src/queues/tchan.rs
+++ b/src/queues/tchan.rs
@@ -1,6 +1,6 @@
 use super::TQueueLike;
 use crate::test_queue_mod;
-use crate::{retry, StmResult, TVar};
+use crate::{retry, Stm, TVar};
 use std::any::Any;
 
 /// A `TVar` that can be empty, or be a cons cell of an item and
@@ -50,7 +50,7 @@ where
         }
     }
 
-    fn is_empty_list(tvl: &TVar<TVarList<T>>) -> StmResult<bool> {
+    fn is_empty_list(tvl: &TVar<TVarList<T>>) -> Stm<bool> {
         let list_var = tvl.read()?;
         let list = list_var.read()?;
         match list.as_ref() {
@@ -79,7 +79,7 @@ where
     /// [ ]       [*]       [*]
     /// read0 ->  read1     write
     /// ```
-    fn read(&self) -> StmResult<T> {
+    fn read(&self) -> Stm<T> {
         let var_list = self.read.read()?;
         let list = var_list.read_clone()?;
         match list {
@@ -101,7 +101,7 @@ where
     /// [*]       [ ]       [*]
     /// read      write0 -> write1
     /// ```
-    fn write(&self, value: T) -> StmResult<()> {
+    fn write(&self, value: T) -> Stm<()> {
         let new_list_end = TVar::new(TList::TNil);
         let var_list = self.write.read()?;
         var_list.write(TList::TCons(value, new_list_end.clone()))?;
@@ -109,7 +109,7 @@ where
         Ok(())
     }
 
-    fn is_empty(&self) -> StmResult<bool> {
+    fn is_empty(&self) -> Stm<bool> {
         if TChan::<T>::is_empty_list(&self.read)? {
             TChan::<T>::is_empty_list(&self.write)
         } else {

--- a/src/queues/tqueue.rs
+++ b/src/queues/tqueue.rs
@@ -1,6 +1,6 @@
 use super::TQueueLike;
 use crate::test_queue_mod;
-use crate::{retry, StmResult, TVar};
+use crate::{retry, Stm, TVar};
 use std::any::Any;
 
 /// Unbounded queue using two vectors.
@@ -38,13 +38,13 @@ impl<T> TQueueLike<T> for TQueue<T>
 where
     T: Any + Sync + Send + Clone,
 {
-    fn write(&self, value: T) -> StmResult<()> {
+    fn write(&self, value: T) -> Stm<()> {
         let mut v = self.write.read_clone()?;
         v.push(value);
         self.write.write(v)
     }
 
-    fn read(&self) -> StmResult<T> {
+    fn read(&self) -> Stm<T> {
         let mut rv = self.read.read_clone()?;
         // Elements are stored in reverse order.
         match rv.pop() {
@@ -67,7 +67,7 @@ where
         }
     }
 
-    fn is_empty(&self) -> StmResult<bool> {
+    fn is_empty(&self) -> Stm<bool> {
         if self.read.read()?.is_empty() {
             Ok(self.write.read()?.is_empty())
         } else {

--- a/src/queues/tvecdequeue.rs
+++ b/src/queues/tvecdequeue.rs
@@ -1,6 +1,6 @@
 use super::TQueueLike;
 use crate::test_queue_mod;
-use crate::{retry, StmResult, TVar};
+use crate::{retry, Stm, TVar};
 use std::{any::Any, collections::VecDeque};
 
 #[derive(Clone)]
@@ -34,13 +34,13 @@ impl<T> TQueueLike<T> for TVecDequeue<T>
 where
     T: Any + Sync + Send + Clone,
 {
-    fn write(&self, value: T) -> StmResult<()> {
+    fn write(&self, value: T) -> Stm<()> {
         let mut queue = self.queue.read_clone()?;
         queue.push_back(value);
         self.queue.write(queue)
     }
 
-    fn read(&self) -> StmResult<T> {
+    fn read(&self) -> Stm<T> {
         let mut queue = self.queue.read_clone()?;
         match queue.pop_front() {
             None => retry(),
@@ -51,7 +51,7 @@ where
         }
     }
 
-    fn is_empty(&self) -> StmResult<bool> {
+    fn is_empty(&self) -> Stm<bool> {
         self.queue.read().map(|v| v.is_empty())
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -208,9 +208,9 @@ async fn nested_abort() {
     let add1 = |x: i32| x + 1;
     let abort = retry;
 
-    fn nested<F>(f: F) -> StmResult<()>
+    fn nested<F>(f: F) -> Stm<()>
     where
-        F: FnOnce() -> StmResult<()>,
+        F: FnOnce() -> Stm<()>,
     {
         or(f, || Ok(()))
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -241,30 +241,39 @@ async fn nested_abort() {
     assert_eq!(*v, 3);
 }
 
-#[derive(Debug, Clone)]
-pub struct TestError;
+// One kind of error.
+#[derive(thiserror::Error, Debug)]
+#[error("test error instance")]
+pub struct TestError1;
 
-impl std::fmt::Display for TestError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "test error instance")
-    }
+// Another kind of unrelated error.
+#[derive(thiserror::Error, Debug)]
+#[error("another error instance")]
+pub struct TestError2;
+
+// An error type unifying both.
+#[derive(thiserror::Error, Debug)]
+pub enum TestError {
+    #[error("error 1: {0}")]
+    Error1(#[from] TestError1),
+    #[error("error 2: {0}")]
+    Error2(#[from] TestError2),
 }
-
-impl Error for TestError {}
 
 #[tokio::test]
 async fn abort_with_error() {
     let a = TVar::new(0);
 
-    let r = atomically_or_err(|| {
+    let r: Result<(), TestError> = atomically_or_err(|| {
         a.write(1)?;
-        abort(TestError)?;
+        abort(TestError1)?;
+        abort(TestError2)?;
         Ok(())
     })
     .await;
 
     assert_eq!(
         r.err().map(|e| e.to_string()),
-        Some("test error instance".to_owned())
+        Some("error 1: test error instance".to_owned())
     );
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,7 +1,7 @@
-use crate::auxtx::*;
 use crate::vars::{LVar, TVar, VVar, ID};
 use crate::version::{current_version, next_version, Version};
-use crate::{StmError, StmResult};
+use crate::StmResult;
+use crate::{auxtx::*, StmControlError};
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -74,7 +74,7 @@ impl Transaction {
                 if guard.version > self.version {
                     // The TVar has been written to since we started this transaction.
                     // There is no point carrying on with the rest of it, but we can retry.
-                    Err(StmError::Failure)
+                    Err(StmControlError::Failure)
                 } else {
                     self.log.insert(
                         tvar.id,

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -1,6 +1,6 @@
 use parking_lot::{Mutex, RwLock};
 
-use crate::{transaction::with_tx, version::Version, StmResult};
+use crate::{transaction::with_tx, version::Version, Stm};
 use std::{
     any::Any,
     marker::PhantomData,
@@ -177,22 +177,22 @@ impl<T: Any + Sync + Send + Clone> TVar<T> {
     }
 
     /// Read the value of the `TVar` as a clone, for subsequent modification. Only call this inside `atomically`.
-    pub fn read_clone(&self) -> StmResult<T> {
+    pub fn read_clone(&self) -> Stm<T> {
         with_tx(|tx| tx.read(self).map(|r| r.as_ref().clone()))
     }
 
     /// Read the value of the `TVar`. Only call this inside `atomically`.
-    pub fn read(&self) -> StmResult<Arc<T>> {
+    pub fn read(&self) -> Stm<Arc<T>> {
         with_tx(|tx| tx.read(self))
     }
 
     /// Replace the value of the `TVar`. Only call this inside `atomically`.
-    pub fn write(&self, value: T) -> StmResult<()> {
+    pub fn write(&self, value: T) -> Stm<()> {
         with_tx(move |tx| tx.write(self, value))
     }
 
     /// Apply an update on the value of the `TVar`. Only call this inside `atomically`.
-    pub fn update<F>(&self, f: F) -> StmResult<()>
+    pub fn update<F>(&self, f: F) -> Stm<()>
     where
         F: FnOnce(T) -> T,
     {
@@ -201,7 +201,7 @@ impl<T: Any + Sync + Send + Clone> TVar<T> {
     }
 
     /// Apply an update on the value of the `TVar`. Only call this inside `atomically`.
-    pub fn update_mut<F>(&self, f: F) -> StmResult<()>
+    pub fn update_mut<F>(&self, f: F) -> Stm<()>
     where
         F: FnOnce(&mut T),
     {
@@ -211,7 +211,7 @@ impl<T: Any + Sync + Send + Clone> TVar<T> {
     }
 
     /// Apply an update on the value of the `TVar` and return a value. Only call this inside `atomically`.
-    pub fn modify<F, R>(&self, f: F) -> StmResult<R>
+    pub fn modify<F, R>(&self, f: F) -> Stm<R>
     where
         F: FnOnce(T) -> (T, R),
     {
@@ -222,7 +222,7 @@ impl<T: Any + Sync + Send + Clone> TVar<T> {
     }
 
     /// Apply an update on the value of the `TVar` and return a value. Only call this inside `atomically`.
-    pub fn modify_mut<F, R>(&self, f: F) -> StmResult<R>
+    pub fn modify_mut<F, R>(&self, f: F) -> Stm<R>
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -233,7 +233,7 @@ impl<T: Any + Sync + Send + Clone> TVar<T> {
     }
 
     /// Replace the value of the `TVar` and return the previous value. Only call this inside `atomically`.
-    pub fn replace(&self, value: T) -> StmResult<Arc<T>> {
+    pub fn replace(&self, value: T) -> Stm<Arc<T>> {
         let v = self.read()?;
         self.write(value)?;
         Ok(v)


### PR DESCRIPTION
This is a breaking change in the API to introduce error signatures in the results. 

### Motivation

Up to now there was
* `StmResult<T>` for methods that cannot fail for business reasons; for these `atomically` returns a `T`
*  `StmDynResult<T>` for methods that can be stopped with `abort` which takes a dynamic error; for these `atomically_or_err` returns a `Result<T, Box<dyn Error>>` and it cannot be used with `atomically` or it panics. Then we have to use `downcast_ref` to check which kind of error we had.

Using a dynamic error had benefits because any kind of error could be combined, and later inspected with `downcast_ref`. However, we used the exact type that we wanted to return, and it's a bit of a shame to have to add unreachable cases that need to be maintained to turn things back into a `Result<T, E>` where `E` is our error type, potentially missing the case of calling another abortable method that returns something else. 

With this change, `atomically_or_err` returns `Result<T, E>` without losing track of that information. The cost is the increased complexity of unifying errors across different methods, ie. if one method uses `E1` and another uses `E2` then there has to be an `E` that both can be converted into. Luckily this is easily doable using [thiserror](https://crates.io/crates/thiserror) and its `#from` construct. 

The most convenient way to call `atomically_or_err` is to declare the error type in return type, e.g.:
```rust
let result: Result<MyThing, MyError> = atomically_or_err(|| {
  abort(MyError)
}).await
```

### Breaking changes

I never liked the `StmDynResult` name, but now that the error isn't even dynamic it really doesn't make sense. To resolve the naming conundrum and trying to avoid `StmAbortableResult` which I thought was way too long, I renamed some public types:

* `StmResult<T>` becomes simply `Stm<T>`, like in Haskell. It's not really a `Result` type anyway, in that it's a `Result` to take advantage of shortcutting semantics, but not because we care about the error. 
* `StmError` was renamed to `StmControl` for the above reason: it's not really an error, just a way to tell the framework to restart. 
* `StmDynError` is now `StmError<E>`
* `StmDynResult<T>` is now `StmResult<T, E>`

So to use this version, most methods that returned `StmResult<T>` now have to be changed to return `Stm<T>`.